### PR TITLE
Adiciona endereço da vaga

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -52,6 +52,7 @@ class JobsController < ApplicationController
     params.require(:job).permit(
       :title,
       :email,
+      :url,
       :company,
       :skills,
       :location,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -3,7 +3,7 @@ class Job < ActiveRecord::Base
 
   validates :title, :description, :email, :company, presence: true
   validates :email, format: { with: /\A[a-z]([\.\-]?\w+)+@[a-z]([\.\-]?\w+){2,}\Z/ }
-  validates :website, format: { with: URI.regexp }, allow_blank: true
+  validates :website, :url, format: { with: URI.regexp }, allow_blank: true
 
   default_scope { order(id: :desc) }
   scope :updated_at_desc, -> { order(updated_at: :desc) }

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -2,12 +2,13 @@
   <div class="col-xs-12 col-md-10 col-md-offset-1">
     <%= simple_form_for @job, wrapper_mappings: { radio_buttons: :vertical_radio_and_checkboxes } do |f| %>
       <%= f.error_notification %>
-      <%= f.input :title %>
       <%= f.input :company %>
+      <%= f.input :website, as: :url %>
+      <%= f.input :title %>
       <%= f.input :modality, as: :radio_buttons, collection: modalities_hash %>
       <%= f.input :location %>
       <%= f.input :email %>
-      <%= f.input :website, as: :url %>
+      <%= f.input :url, as: :url %>
       <%= f.input :skills %>
       <%= f.input :description %>
       <%= f.input :salary, as: :radio_buttons, collection: salaries_hash %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -41,7 +41,11 @@
       <div class="col-xs-12 col-sm-12 col-md-11 col-lg-11">
         <h4> Gostou da vaga? </h4>
         <p>
+          <% if @job.url.present? %>
+            <%= link_to 'Participe do processo de seleção', @job.url %> e caso seja contratado deixe-nos saber!
+          <% else %>
           Entre em contato com o responsável pelo email <%= content_tag :span, @job.email, class: "email" %> e caso seja contratado deixe-nos saber!
+          <% end %>
         </p>
       </div>
 

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -10,11 +10,13 @@ pt-BR:
   simple_form:
     labels:
       job:
-        title: "Título"
+        title: "Título da vaga"
         company: "Empresa"
+        website: "Site da empresa"
         modality: "Qual é a modalidade de trabalho?"
         location: "Localização"
         email: "E-mail para contato"
+        url: "Endereço da vaga (quando preenchido, os candidatos serão encaminhados para este endereço)"
         skills: "Habilidades/Requerimentos"
         description: "Descrição"
         min_salary: "Salário (de)"
@@ -25,6 +27,7 @@ pt-BR:
         company: "Empresa S/A"
         location: 'Rio de Janeiro - RJ'
         email: 'contato@empresa.com'
+        url: "http://www.seusite.com.br/sua_vaga"
         website: 'http://www.seusite.com.br'
         skills: 'Necessário ter experiência com: Ruby, Ruby on Rails ou outro framework MVC.  Desejável: APIs REST, Test Driven Development, MongoDB e GIT'
         description: 'Estamos contratando desenvolvedor Ruby/Rails, que já tenha experiência. Trabalhamos com metodologias ágeis, se tiver esta vivência também é legal =) Não precisa ser do Rio, contratamos pessoas remotas também. '

--- a/db/migrate/20150120095819_add_url_to_job.rb
+++ b/db/migrate/20150120095819_add_url_to_job.rb
@@ -1,0 +1,5 @@
+class AddUrlToJob < ActiveRecord::Migration
+  def change
+    add_column :jobs, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150117175540) do
+ActiveRecord::Schema.define(version: 20150120095819) do
 
   create_table "jobs", force: true do |t|
     t.string   "title"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20150117175540) do
     t.integer  "modality",    default: 0
     t.string   "website"
     t.integer  "salary",      default: 0
+    t.string   "url"
   end
 
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -14,6 +14,8 @@ describe Job do
       it { expect(subject).not_to allow_value('m@e.com').for(:email) }
       it { expect(subject).to allow_value('http://www.site.com').for(:website) }
       it { expect(subject).not_to allow_value('site.com').for(:website) }
+      it { expect(subject).to allow_value('http://www.site.com').for(:url) }
+      it { expect(subject).not_to allow_value('site.com').for(:url) }
     end
   end
 


### PR DESCRIPTION
Criei um novo PR pois achei que não seria legal deixar no histórico o campo sendo adicionado e depois renomeado. E não consegui remover o histórico e manter na mesma branch.

Conforme conversado no #70, #74 e #76, esta modificação adiciona o campo `url` usando label `Endereço da vaga`. Quando este campo estiver preenchido, o e-mail de contato não é divulgado, e os candidatos são direcionados a URL.

Fixes #70 